### PR TITLE
Fixed Modal Regression

### DIFF
--- a/project/client/like-home/src/stylesheets/SignUp.scss
+++ b/project/client/like-home/src/stylesheets/SignUp.scss
@@ -65,6 +65,11 @@ label {
     padding-top: 0px;
 }
 
+b {
+  font-size: 16px;
+  color: black;
+}
+
 .closebutton {
   float: right;
   border-radius: 30px;


### PR DESCRIPTION
fixed a regression in the text labels on modals sign up and login not…showing and being white and font being oversized

Back to normal:

 
<img width="1392" alt="screen shot 2018-04-06 at 6 12 24 pm" src="https://user-images.githubusercontent.com/4329447/38449640-4aca1c6c-39c6-11e8-8389-cb3338ef20f0.png">
<img width="1392" alt="screen shot 2018-04-06 at 6 12 19 pm" src="https://user-images.githubusercontent.com/4329447/38449642-4cf55bd2-39c6-11e8-9f32-f5924f533ab4.png">

